### PR TITLE
Update extensions to return null for null input parameters

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/math/AbsFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/AbsFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * abs(a);
@@ -95,22 +96,7 @@ public class AbsFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.abs((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.abs((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.abs((double) inputFloat);
-            } else if (data instanceof Double) {
-                double inputValue = (Double) data;
-                return Math.abs(inputValue);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:abs() function cannot be null");
+            return Math.abs(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/AcosFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/AcosFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * acos(a);
@@ -95,16 +96,7 @@ public class AcosFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.acos((double) inputFloat);
-            } else if (data instanceof Double) {
-                double inputValue = (Double) data;
-                return Math.acos(inputValue);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:acos() function cannot be null");
+            return Math.acos(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/AsinFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/AsinFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * asin(a);
@@ -91,16 +92,7 @@ public class AsinFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.asin((double) inputFloat);
-            } else if (data instanceof Double) {
-                double inputValue = (Double) data;
-                return Math.asin(inputValue);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:asin() function cannot be null");
+            return Math.asin(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/AtanFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/AtanFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * atan(a); or atan(a,b);
@@ -106,65 +107,16 @@ public class AtanFunctionExtension extends FunctionExecutor {
 
     @Override
     protected Object execute(Object[] data, State state) {
-        double inputVal1 = 0d;
-        double inputVal2 = 0d;
-
-        if (data[0] != null) {
-            //type-conversion
-            if (data[0] instanceof Integer) {
-                int inputInt = (Integer) data[0];
-                inputVal1 = (double) inputInt;
-            } else if (data[0] instanceof Long) {
-                long inputLong = (Long) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Float) {
-                float inputLong = (Float) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Double) {
-                inputVal1 = (Double) data[0];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:atan() function cannot be null");
+        if (data[0] != null && data[1] != null) {
+            return Math.atan2(convertToDouble(data[0]), convertToDouble(data[1]));
         }
-
-        if (data[1] != null) {
-            //type-conversion
-            if (data[1] instanceof Integer) {
-                int inputInt = (Integer) data[1];
-                inputVal2 = (double) inputInt;
-            } else if (data[1] instanceof Long) {
-                long inputLong = (Long) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Float) {
-                float inputLong = (Float) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Double) {
-                inputVal2 = (Double) data[1];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:atan() function cannot be null");
-        }
-        return Math.atan2(inputVal1, inputVal2);
+        return null;
     }
 
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.atan((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.atan((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.atan((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.atan((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:atan() function cannot be null");
+            return Math.atan(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/BinaryFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/BinaryFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -98,9 +97,8 @@ public class BinaryFunctionExtension extends FunctionExecutor {
             } else {
                 return Long.toBinaryString((Long) data);
             }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:bin() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/CeilingFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/CeilingFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -99,9 +98,8 @@ public class CeilingFunctionExtension extends FunctionExecutor {
             } else {
                 return Math.ceil((Double) data);
             }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:ceil() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/ConvertFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/ConvertFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -102,23 +101,14 @@ public class ConvertFunctionExtension extends FunctionExecutor {
 
     @Override
     protected Object execute(Object[] data, State state) {
-        if (data[0] == null) {
-            throw new SiddhiAppRuntimeException("Invalid input given to math:conv() function. " +
-                    "First argument cannot be null");
+        if (data[0] != null && data[1] != null && data[2] != null) {
+            String nValue = (String) data[0];
+            int fromBase = (Integer) data[1];
+            int toBase = (Integer) data[2];
+            return Integer.toString(
+                    Integer.parseInt(nValue, fromBase), toBase);
         }
-        if (data[1] == null) {
-            throw new SiddhiAppRuntimeException("Invalid input given to math:conv() function. " +
-                    "Second argument cannot be null");
-        }
-        if (data[2] == null) {
-            throw new SiddhiAppRuntimeException("Invalid input given to math:conv() function. " +
-                    "Third argument cannot be null");
-        }
-        String nValue = (String) data[0];
-        int fromBase = (Integer) data[1];
-        int toBase = (Integer) data[2];
-        return Integer.toString(
-                Integer.parseInt(nValue, fromBase), toBase);
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/CopySignFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/CopySignFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * copysign(magnitude,sign);
@@ -102,44 +103,10 @@ public class CopySignFunctionExtension extends FunctionExecutor {
 
     @Override
     protected Object execute(Object[] data, State state) {
-        double inputVal1 = 0d;
-        double inputVal2 = 0d;
-
-        if (data[0] != null) {
-            //type-conversion
-            if (data[0] instanceof Integer) {
-                int inputInt = (Integer) data[0];
-                inputVal1 = (double) inputInt;
-            } else if (data[0] instanceof Long) {
-                long inputLong = (Long) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Float) {
-                float inputLong = (Float) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Double) {
-                inputVal1 = (Double) data[0];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:copysign() function cannot be null");
+        if (data[0] != null && data[1] != null) {
+            return Math.copySign(convertToDouble(data[0]), convertToDouble(data[1]));
         }
-        if (data[1] != null) {
-            //type-conversion
-            if (data[1] instanceof Integer) {
-                int inputInt = (Integer) data[1];
-                inputVal2 = (double) inputInt;
-            } else if (data[1] instanceof Long) {
-                long inputLong = (Long) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Float) {
-                float inputLong = (Float) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Double) {
-                inputVal2 = (Double) data[1];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:copysign() function cannot be null");
-        }
-        return Math.copySign(inputVal1, inputVal2);
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/CosFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/CosFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * cos(a);
@@ -93,21 +94,7 @@ public class CosFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.cos((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.cos((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.cos((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.cos((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:cos() function cannot be null");
+            return Math.cos(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/CoshFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/CoshFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * cosh(a);
@@ -92,21 +93,7 @@ public class CoshFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.cosh((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.cosh((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.cosh((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.cosh((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:cosh() function cannot be null");
+            return Math.cosh(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/CubeRootFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/CubeRootFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * cbrt(a);
@@ -92,21 +93,7 @@ public class CubeRootFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.cbrt((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.cbrt((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.cbrt((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.cbrt((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:cbrt() function cannot be null");
+            return Math.cbrt(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/ExponentFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/ExponentFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * exp(a)
@@ -91,21 +92,7 @@ public class ExponentFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.exp((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.exp((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.exp((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.exp((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:exp() function cannot be null");
+            return Math.exp(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/FloorFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/FloorFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * floor(a)
@@ -94,21 +95,7 @@ public class FloorFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.floor((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.floor((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.floor((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.floor((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:floor() function cannot be null");
+            return Math.floor(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/GetExponentFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/GetExponentFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * get_exponent(a)
@@ -92,20 +93,7 @@ public class GetExponentFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.getExponent((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.getExponent((double) inputLong);
-            } else if (data instanceof Float) {
-                return Math.getExponent((Float) data);
-            } else if (data instanceof Double) {
-                return Math.getExponent((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:getExponent() function cannot be null");
+            return Math.getExponent(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/HexFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/HexFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -102,8 +101,6 @@ public class HexFunctionExtension extends FunctionExecutor {
             } else if (data instanceof Double) {
                 return Double.toHexString((Double) data);
             }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:hex() function cannot be null");
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/IsInfiniteFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/IsInfiniteFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -99,9 +98,8 @@ public class IsInfiniteFunctionExtension extends FunctionExecutor {
             } else {
                 return Double.isInfinite((Double) data);
             }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:isInfinite() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/IsNanFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/IsNanFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -96,9 +95,8 @@ public class IsNanFunctionExtension extends FunctionExecutor {
             } else {
                 return Double.isNaN((Double) data);
             }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:isNan() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/LnFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/LnFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * ln(a);
@@ -92,21 +93,7 @@ public class LnFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.log((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.log((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.log((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.log((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:ln() function cannot be null");
+            return Math.log(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/Log10FunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/Log10FunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * log10(a);
@@ -91,21 +92,7 @@ public class Log10FunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.log10((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.log10((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.log10((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.log10((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:log10() function cannot be null");
+            return Math.log10(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/Log2FunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/Log2FunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * log2(a);
@@ -91,21 +92,7 @@ public class Log2FunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.log((double) inputInt) / Math.log(2d);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.log((double) inputLong) / Math.log(2d);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.log((double) inputFloat) / Math.log(2d);
-            } else if (data instanceof Double) {
-                return Math.log((Double) data) / Math.log(2d);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:log2() function cannot be null");
+            return Math.log(convertToDouble(data)) / Math.log(2d);
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/LogFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/LogFunctionExtension.java
@@ -33,6 +33,8 @@ import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
 
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
+
 /**
  * log(number,base);
  * Returns the logarithm (base='base') of the given 'number'.
@@ -102,50 +104,17 @@ public class LogFunctionExtension extends FunctionExecutor {
 
     @Override
     protected Object execute(Object[] data, State state) {
-        double number = 0d;
-        double base = 0d;
-        double outputValue;
-
-        if (data[0] != null) {
-            //type-conversion
-            if (data[0] instanceof Integer) {
-                int inputInt = (Integer) data[0];
-                number = (double) inputInt;
-            } else if (data[0] instanceof Long) {
-                long inputLong = (Long) data[0];
-                number = (double) inputLong;
-            } else if (data[0] instanceof Float) {
-                float inputLong = (Float) data[0];
-                number = (double) inputLong;
-            } else if (data[0] instanceof Double) {
-                number = (Double) data[0];
+        if (data[0] != null && data[1] != null) {
+            double number = convertToDouble(data[0]);
+            double base = convertToDouble(data[1]);
+            if (base == 1) {
+                throw new SiddhiAppRuntimeException("The base argument supplied to the math:log() function "
+                        + "is equal to zero. Since the logarithms to the base 1 is undefined, "
+                        + "the result of math:log(" + number + "," + base + ") is undefined");
             }
-        } else {
-            throw new SiddhiAppRuntimeException("The first argument to the math:log() function cannot be null");
+            return Math.log(number) / Math.log(base);
         }
-        if (data[1] != null) {
-            //type-conversion
-            if (data[1] instanceof Integer) {
-                int inputInt = (Integer) data[1];
-                base = (double) inputInt;
-            } else if (data[1] instanceof Long) {
-                long inputLong = (Long) data[1];
-                base = (double) inputLong;
-            } else if (data[1] instanceof Float) {
-                float inputLong = (Float) data[1];
-                base = (double) inputLong;
-            } else if (data[1] instanceof Double) {
-                base = (Double) data[1];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("The second argument to the math:log() function cannot be null");
-        }
-        if (base == 1) {
-            throw new SiddhiAppRuntimeException("The base argument supplied to the math:log() function is equal to " +
-                    "zero. Since the logarithms to the base 1 is undefined, the result of math:log(" + number + "," +
-                    base + ") is undefined");
-        }
-        return Math.log(number) / Math.log(base);
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/MaxFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/MaxFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * max(a,b);
@@ -101,43 +102,10 @@ public class MaxFunctionExtension extends FunctionExecutor {
 
     @Override
     protected Object execute(Object[] data, State state) {
-        double inputVal1 = 0d;
-        double inputVal2 = 0d;
-        if (data[0] != null) {
-            //type-conversion
-            if (data[0] instanceof Integer) {
-                int inputInt = (Integer) data[0];
-                inputVal1 = (double) inputInt;
-            } else if (data[0] instanceof Long) {
-                long inputLong = (Long) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Float) {
-                float inputLong = (Float) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Double) {
-                inputVal1 = (Double) data[0];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:max() function cannot be null");
+        if (data[0] != null && data[1] != null) {
+            return Math.max(convertToDouble(data[0]), convertToDouble(data[1]));
         }
-        if (data[1] != null) {
-            //type-conversion
-            if (data[1] instanceof Integer) {
-                int inputInt = (Integer) data[1];
-                inputVal2 = (double) inputInt;
-            } else if (data[1] instanceof Long) {
-                long inputLong = (Long) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Float) {
-                float inputLong = (Float) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Double) {
-                inputVal2 = (Double) data[1];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:max() function cannot be null");
-        }
-        return Math.max(inputVal1, inputVal2);
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/MinFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/MinFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * min(a,b);
@@ -101,43 +102,10 @@ public class MinFunctionExtension extends FunctionExecutor {
 
     @Override
     protected Object execute(Object[] data, State state) {
-        double inputVal1 = 0d;
-        double inputVal2 = 0d;
-        if (data[0] != null) {
-            //type-conversion
-            if (data[0] instanceof Integer) {
-                int inputInt = (Integer) data[0];
-                inputVal1 = (double) inputInt;
-            } else if (data[0] instanceof Long) {
-                long inputLong = (Long) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Float) {
-                float inputLong = (Float) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Double) {
-                inputVal1 = (Double) data[0];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:min() function cannot be null");
+        if (data[0] != null && data[1] != null) {
+            return Math.min(convertToDouble(data[0]), convertToDouble(data[1]));
         }
-        if (data[1] != null) {
-            //type-conversion
-            if (data[1] instanceof Integer) {
-                int inputInt = (Integer) data[1];
-                inputVal2 = (double) inputInt;
-            } else if (data[1] instanceof Long) {
-                long inputLong = (Long) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Float) {
-                float inputLong = (Float) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Double) {
-                inputVal2 = (Double) data[1];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:min() function cannot be null");
-        }
-        return Math.min(inputVal1, inputVal2);
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/OctalFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/OctalFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -93,9 +92,8 @@ public class OctalFunctionExtension extends FunctionExecutor {
             } else {
                 return Long.toOctalString((Long) data);
             }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:oct() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/ParseDoubleFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/ParseDoubleFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -88,9 +87,8 @@ public class ParseDoubleFunctionExtension extends FunctionExecutor {
     protected Object execute(Object data, State state) {
         if (data != null) {
             return Double.parseDouble((String) data);
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:parseDouble() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/ParseFloatFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/ParseFloatFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -88,9 +87,8 @@ public class ParseFloatFunctionExtension extends FunctionExecutor {
     protected Object execute(Object data, State state) {
         if (data != null) {
             return Float.parseFloat((String) data);
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:parseFloat() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/ParseIntFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/ParseIntFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -86,9 +85,8 @@ public class ParseIntFunctionExtension extends FunctionExecutor {
     protected Object execute(Object data, State state) {
         if (data != null) {
             return Integer.parseInt((String) data);
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:parseInt() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/ParseLongFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/ParseLongFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -86,9 +85,8 @@ public class ParseLongFunctionExtension extends FunctionExecutor {
     protected Object execute(Object data, State state) {
         if (data != null) {
             return Long.parseLong((String) data);
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:parseLong() function cannot be null");
         }
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/PowerFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/PowerFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * power(value,toPower);
@@ -102,45 +103,10 @@ public class PowerFunctionExtension extends FunctionExecutor {
 
     @Override
     protected Object execute(Object[] data, State state) {
-        double inputVal1 = 0d;
-        double inputVal2 = 0d;
-        double outputValue = 0d;
-
-        if (data[0] != null) {
-            //type-conversion
-            if (data[0] instanceof Integer) {
-                int inputInt = (Integer) data[0];
-                inputVal1 = (double) inputInt;
-            } else if (data[0] instanceof Long) {
-                long inputLong = (Long) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Float) {
-                float inputLong = (Float) data[0];
-                inputVal1 = (double) inputLong;
-            } else if (data[0] instanceof Double) {
-                inputVal1 = (Double) data[0];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:power() function cannot be null");
+        if (data[0] != null && data[1] != null) {
+            return Math.pow(convertToDouble(data[0]), convertToDouble(data[1]));
         }
-        if (data[1] != null) {
-            //type-conversion
-            if (data[1] instanceof Integer) {
-                int inputInt = (Integer) data[1];
-                inputVal2 = (double) inputInt;
-            } else if (data[1] instanceof Long) {
-                long inputLong = (Long) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Float) {
-                float inputLong = (Float) data[1];
-                inputVal2 = (double) inputLong;
-            } else if (data[1] instanceof Double) {
-                inputVal2 = (Double) data[1];
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:power() function cannot be null");
-        }
-        return Math.pow(inputVal1, inputVal2);
+        return null;
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/math/RoundFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/RoundFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -105,8 +104,6 @@ public class RoundFunctionExtension extends FunctionExecutor {
                 double inputValue = (Double) data;
                 return Math.round(inputValue);
             }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:round() function cannot be null");
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/SignFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/SignFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * signum(a);
@@ -94,25 +95,8 @@ public class SignFunctionExtension extends FunctionExecutor {
 
     @Override
     protected Object execute(Object data, State state) {
-        double inputValue = 0d;
-        double returnValue = 0d;
-
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return (int) Math.signum((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return (int) Math.signum((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return (int) Math.signum((double) inputFloat);
-            } else if (data instanceof Double) {
-                return (int) Math.signum((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:signum() function cannot be null");
+            return (int) Math.signum(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/SinFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/SinFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * sin(a);
@@ -93,21 +94,7 @@ public class SinFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.sin((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.sin((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.sin((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.sin((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:sin() function cannot be null");
+            return Math.sin(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/SinhFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/SinhFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * sinh(a);
@@ -93,21 +94,7 @@ public class SinhFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.sinh((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.sinh((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.sinh((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.sinh((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:sinh() function cannot be null");
+            return Math.sinh(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/SquareRootFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/SquareRootFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * sqrt(a);
@@ -92,22 +93,7 @@ public class SquareRootFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.sqrt((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.sqrt((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.sqrt((double) inputFloat);
-            } else if (data instanceof Double) {
-                double inputValue = (Double) data;
-                return Math.sqrt(inputValue);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:sqrt() function cannot be null");
+            return Math.sqrt(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/TanFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/TanFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * tan(a);
@@ -93,21 +94,7 @@ public class TanFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.tan((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.tan((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.tan((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.tan((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:tan() function cannot be null");
+            return Math.tan(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/TanhFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/TanhFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * tanh(a);
@@ -93,22 +94,7 @@ public class TanhFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.tanh((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.tanh((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.tanh((double) inputFloat);
-            } else if (data instanceof Double) {
-                double inputValue = (Double) data;
-                return Math.tanh(inputValue);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:tanh() function cannot be null");
+            return Math.tanh(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/ToDegreesFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/ToDegreesFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * to_degrees(a);
@@ -94,21 +95,7 @@ public class ToDegreesFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.toDegrees((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.toDegrees((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.toDegrees((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.toDegrees((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:toDegrees() function cannot be null");
+            return Math.toDegrees(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/ToRadiansFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/ToRadiansFunctionExtension.java
@@ -24,7 +24,6 @@ import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.ReturnAttribute;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.config.SiddhiQueryContext;
-import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.executor.ExpressionExecutor;
 import io.siddhi.core.executor.function.FunctionExecutor;
 import io.siddhi.core.util.config.ConfigReader;
@@ -32,6 +31,8 @@ import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.snapshot.state.StateFactory;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
+
+import static io.siddhi.extension.execution.math.util.MathUtil.convertToDouble;
 
 /**
  * to_radians(a)
@@ -91,21 +92,7 @@ public class ToRadiansFunctionExtension extends FunctionExecutor {
     @Override
     protected Object execute(Object data, State state) {
         if (data != null) {
-            //type-conversion
-            if (data instanceof Integer) {
-                int inputInt = (Integer) data;
-                return Math.toRadians((double) inputInt);
-            } else if (data instanceof Long) {
-                long inputLong = (Long) data;
-                return Math.toRadians((double) inputLong);
-            } else if (data instanceof Float) {
-                float inputFloat = (Float) data;
-                return Math.toRadians((double) inputFloat);
-            } else if (data instanceof Double) {
-                return Math.toRadians((Double) data);
-            }
-        } else {
-            throw new SiddhiAppRuntimeException("Input to the math:toRadians() function cannot be null");
+            return Math.toRadians(convertToDouble(data));
         }
         return null;
     }

--- a/component/src/main/java/io/siddhi/extension/execution/math/util/MathUtil.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/util/MathUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c)  2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.extension.execution.math.util;
+
+import io.siddhi.core.exception.SiddhiAppRuntimeException;
+import io.siddhi.query.api.definition.Attribute;
+
+/**
+ * Util class for the extensions
+ */
+public class MathUtil {
+
+    /**
+     * Converts the input to double
+     */
+    public static double convertToDouble(Object data) {
+        if (data instanceof Integer) {
+            int inputInt = (Integer) data;
+            return (double) inputInt;
+        } else if (data instanceof Long) {
+            long inputLong = (Long) data;
+            return (double) inputLong;
+        } else if (data instanceof Float) {
+            float inputLong = (Float) data;
+            return (double) inputLong;
+        } else if (data instanceof Double) {
+            return (Double) data;
+        }
+        throw new SiddhiAppRuntimeException("Invalid parameter type found as the input of math:atan() function," +
+                "required " + Attribute.Type.INT + " or " + Attribute.Type.LONG +
+                " or " + Attribute.Type.FLOAT + " or " + Attribute.Type.DOUBLE +
+                ", but found " + data.getClass());
+    }
+}

--- a/component/src/main/java/io/siddhi/extension/execution/math/util/MathUtil.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/util/MathUtil.java
@@ -27,8 +27,12 @@ public class MathUtil {
 
     /**
      * Converts the input to double
+     *
+     * @param data Input for the conversion
+     * @return Double value
      */
     public static double convertToDouble(Object data) {
+
         if (data instanceof Integer) {
             int inputInt = (Integer) data;
             return (double) inputInt;
@@ -41,9 +45,9 @@ public class MathUtil {
         } else if (data instanceof Double) {
             return (Double) data;
         }
-        throw new SiddhiAppRuntimeException("Invalid parameter type found as the input of math:atan() function," +
-                "required " + Attribute.Type.INT + " or " + Attribute.Type.LONG +
-                " or " + Attribute.Type.FLOAT + " or " + Attribute.Type.DOUBLE +
-                ", but found " + data.getClass());
+        throw new SiddhiAppRuntimeException("Failed to convert to double, "
+                + "invalid parameter type:" + data.getClass() + " . Only supports converting " + Attribute.Type.INT
+                + ", " + Attribute.Type.LONG + ", " + Attribute.Type.FLOAT + "and " + Attribute.Type.DOUBLE
+                + "types to double.");
     }
 }

--- a/component/src/main/java/io/siddhi/extension/execution/math/util/MathUtil.java
+++ b/component/src/main/java/io/siddhi/extension/execution/math/util/MathUtil.java
@@ -34,14 +34,11 @@ public class MathUtil {
     public static double convertToDouble(Object data) {
 
         if (data instanceof Integer) {
-            int inputInt = (Integer) data;
-            return (double) inputInt;
+            return ((Integer) data).doubleValue();
         } else if (data instanceof Long) {
-            long inputLong = (Long) data;
-            return (double) inputLong;
+            return ((Long) data).doubleValue();
         } else if (data instanceof Float) {
-            float inputLong = (Float) data;
-            return (double) inputLong;
+            return ((Float) data).doubleValue();
         } else if (data instanceof Double) {
             return (Double) data;
         }

--- a/component/src/test/java/io/siddhi/extension/execution/math/AbsFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/AbsFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class AbsFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(AbsFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class AbsFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class AbsFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/AbsFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/AbsFunctionExtensionTestCase.java
@@ -23,12 +23,9 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
-import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
@@ -98,9 +95,6 @@ public class AbsFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("AbsFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -115,6 +109,9 @@ public class AbsFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -122,7 +119,6 @@ public class AbsFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        Assert.assertTrue(appender.getMessages().contains("Input to the math:abs() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/AcosFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/AcosFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -193,9 +191,6 @@ public class AcosFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("AcosFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -210,6 +205,9 @@ public class AcosFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -217,7 +215,6 @@ public class AcosFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:acos() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/AcosFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/AcosFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class AcosFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(AcosFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess1() throws Exception {
@@ -205,6 +212,7 @@ public class AcosFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -215,6 +223,7 @@ public class AcosFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/AsinFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/AsinFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class AsinFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(AsinFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -110,6 +117,7 @@ public class AsinFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -120,6 +128,7 @@ public class AsinFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/AsinFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/AsinFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -98,9 +96,6 @@ public class AsinFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("AsinFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -115,6 +110,9 @@ public class AsinFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -122,7 +120,6 @@ public class AsinFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:asin() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/AtanFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/AtanFunctionExtensionTestCase.java
@@ -27,10 +27,17 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class AtanFunctionExtensionTestCase {
     private static Logger logger = Logger.getLogger(AtanFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess1() throws Exception {
@@ -141,6 +148,7 @@ public class AtanFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -151,6 +159,7 @@ public class AtanFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 
@@ -171,6 +180,7 @@ public class AtanFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -181,6 +191,7 @@ public class AtanFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{12d, null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/AtanFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/AtanFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -129,9 +127,6 @@ public class AtanFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("AtanFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -146,6 +141,9 @@ public class AtanFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -153,16 +151,12 @@ public class AtanFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:atan() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
     @Test
     public void exceptionTestCase4() throws Exception {
         logger.info("AtanFunctionExtension exceptionTestCase4");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double, inValue2 double);";
 
@@ -177,6 +171,9 @@ public class AtanFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -184,7 +181,6 @@ public class AtanFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{12d, null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:atan() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/BinaryFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/BinaryFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class BinaryFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(BinaryFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class BinaryFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class BinaryFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/BinaryFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/BinaryFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class BinaryFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("BinaryFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue long);";
 
@@ -114,6 +109,9 @@ public class BinaryFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class BinaryFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:bin() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/CeilingFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CeilingFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class CeilingFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(CeilingFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class CeilingFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class CeilingFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/CeilingFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CeilingFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class CeilingFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("CeilingFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class CeilingFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class CeilingFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:ceil() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/ConvertFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ConvertFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -126,9 +124,6 @@ public class ConvertFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase5() throws Exception {
         logger.info("ConvertFunctionExtension exceptionTestCase5");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue string,fromBase int,toBase int);";
 
@@ -143,6 +138,9 @@ public class ConvertFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -150,72 +148,6 @@ public class ConvertFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 16, 10});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to math:conv() function. "
-                                                                       + "First argument cannot be null."));
-        siddhiAppRuntime.shutdown();
-    }
-
-    @Test
-    public void exceptionTestCase6() throws Exception {
-        logger.info("ConvertFunctionExtension exceptionTestCase6");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
-        siddhiManager = new SiddhiManager();
-        String inValueStream = "define stream InValueStream (inValue string,fromBase int,toBase int);";
-
-        String eventFuseExecutionPlan = ("@info(name = 'query1') from InValueStream "
-                                         + "select math:conv(inValue,fromBase,toBase) as convertedValue "
-                                         + "insert into OutMediationStream;");
-        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inValueStream +
-                                                                                             eventFuseExecutionPlan);
-
-        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents,
-                                Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-            }
-        });
-        InputHandler inputHandler = siddhiAppRuntime
-                .getInputHandler("InValueStream");
-        siddhiAppRuntime.start();
-        inputHandler.send(new Object[]{"7f", null, 10});
-        Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to math:conv() function. "
-                                                                       + "Second argument cannot be null."));
-        siddhiAppRuntime.shutdown();
-    }
-
-    @Test
-    public void exceptionTestCase7() throws Exception {
-        logger.info("ConvertFunctionExtension exceptionTestCase7");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
-        siddhiManager = new SiddhiManager();
-        String inValueStream = "define stream InValueStream (inValue string,fromBase int,toBase int);";
-
-        String eventFuseExecutionPlan = ("@info(name = 'query1') from InValueStream "
-                                         + "select math:conv(inValue,fromBase,toBase) as convertedValue "
-                                         + "insert into OutMediationStream;");
-        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inValueStream +
-                                                                                             eventFuseExecutionPlan);
-
-        siddhiAppRuntime.addCallback("query1", new QueryCallback() {
-            @Override
-            public void receive(long timeStamp, Event[] inEvents,
-                                Event[] removeEvents) {
-                EventPrinter.print(timeStamp, inEvents, removeEvents);
-            }
-        });
-        InputHandler inputHandler = siddhiAppRuntime
-                .getInputHandler("InValueStream");
-        siddhiAppRuntime.start();
-        inputHandler.send(new Object[]{"7f", 16, null});
-        Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to math:conv() function. "
-                                                                       + "Third argument cannot be null."));
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/ConvertFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ConvertFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ConvertFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(ConvertFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -138,6 +145,7 @@ public class ConvertFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -148,6 +156,7 @@ public class ConvertFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 16, 10});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/CopySignFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CopySignFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class CopySignFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(CopySignFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -122,6 +129,7 @@ public class CopySignFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -132,6 +140,7 @@ public class CopySignFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null, -3.0d});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 
@@ -152,6 +161,7 @@ public class CopySignFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -162,6 +172,7 @@ public class CopySignFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{5.6d, null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/CopySignFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CopySignFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -110,9 +108,6 @@ public class CopySignFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase4() throws Exception {
         logger.info("CopySignFunctionExtension exceptionTestCase4");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double, inValue2 double);";
 
@@ -127,6 +122,9 @@ public class CopySignFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -134,16 +132,12 @@ public class CopySignFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null, -3.0d});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:copysign() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
     @Test
     public void exceptionTestCase5() throws Exception {
         logger.info("CopySignFunctionExtension exceptionTestCase5");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double, inValue2 double);";
 
@@ -158,6 +152,9 @@ public class CopySignFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -165,7 +162,6 @@ public class CopySignFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{5.6d, null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:copysign() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/CosFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CosFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class CosFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("CosFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,13 +109,16 @@ public class CosFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
                 .getInputHandler("InValueStream");
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:cos() function cannot be null"));
+        siddhiAppRuntime.shutdown();
     }
 
     @Test

--- a/component/src/test/java/io/siddhi/extension/execution/math/CosFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CosFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class CosFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(CosFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -108,6 +115,7 @@ public class CosFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
+                eventArrived = true;
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
@@ -118,6 +126,7 @@ public class CosFunctionExtensionTestCase {
                 .getInputHandler("InValueStream");
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/CoshFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CoshFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class CoshFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("CoshFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class CoshFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class CoshFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:cosh() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/CoshFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CoshFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class CoshFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(CoshFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class CoshFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class CoshFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/CubeRootFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CubeRootFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class CubeRootFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("CubeRootFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class CubeRootFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class CubeRootFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:cbrt() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/CubeRootFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/CubeRootFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class CubeRootFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(CubeRootFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class CubeRootFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class CubeRootFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/ExponentFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ExponentFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class ExponentFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("ExponentFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class ExponentFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class ExponentFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:exp() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/ExponentFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ExponentFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ExponentFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(ExponentFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class ExponentFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class ExponentFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/FloorFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/FloorFunctionExtensionTestCase.java
@@ -28,11 +28,18 @@ import io.siddhi.core.stream.output.StreamCallback;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class FloorFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(FloorFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -110,6 +117,7 @@ public class FloorFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -120,6 +128,7 @@ public class FloorFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 
@@ -240,9 +249,9 @@ public class FloorFunctionExtensionTestCase {
             @Override
             public void receive(Event[] events) {
                 EventPrinter.print(events);
-                Double result;
+                eventArrived = true;
                 for (Event event : events) {
-                    result = (Double) event.getData(1);
+                    Double result = (Double) event.getData(1);
                     AssertJUnit.assertEquals((Double) 25.0, result);
                 }
             }
@@ -255,6 +264,7 @@ public class FloorFunctionExtensionTestCase {
         windowStreamHandler.send(new Object[]{"Cake", 25.50, 10});
         eventStreamHandler.send(new Object[]{"Cake", 50});
         Thread.sleep(100);
+        eventArrived = true;
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/GetExponentFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/GetExponentFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class GetExponentFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("GetExponentFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class GetExponentFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,8 +119,6 @@ public class GetExponentFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:getExponent() function cannot be "
-                                                                       + "null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/GetExponentFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/GetExponentFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class GetExponentFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(GetExponentFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class GetExponentFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class GetExponentFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/HexFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/HexFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class HexFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(HexFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class HexFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class HexFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/HexFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/HexFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class HexFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("HexFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue int);";
 
@@ -114,6 +109,9 @@ public class HexFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class HexFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:hex() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/IsInfiniteFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/IsInfiniteFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class IsInfiniteFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("IsInfiniteFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double,inValue2 int);";
 
@@ -114,6 +109,9 @@ public class IsInfiniteFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(false, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,8 +119,6 @@ public class IsInfiniteFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 91});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:isInfinite() function cannot be "
-                                                                       + "null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/IsInfiniteFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/IsInfiniteFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class IsInfiniteFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(IsInfiniteFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class IsInfiniteFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(false, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class IsInfiniteFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 91});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/IsNanFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/IsNanFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class IsNanFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(IsNanFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class IsNanFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(false, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class IsNanFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 91});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/IsNanFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/IsNanFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class IsNanFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("IsNanFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double,inValue2 int);";
 
@@ -114,6 +109,9 @@ public class IsNanFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(false, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class IsNanFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 91});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:isNan() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/LnFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/LnFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class LnFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(LnFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class LnFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class LnFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/LnFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/LnFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class LnFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("LnFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class LnFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class LnFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:ln() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/Log10FunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/Log10FunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class Log10FunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(Log10FunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class Log10FunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class Log10FunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/Log10FunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/Log10FunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class Log10FunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("Log10FunctionExtension exceptionTestCase2");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class Log10FunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class Log10FunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:log10() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/Log2FunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/Log2FunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class Log2FunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("Log2FunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class Log2FunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class Log2FunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:log2() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/Log2FunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/Log2FunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class Log2FunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(Log2FunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class Log2FunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class Log2FunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/LogFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/LogFunctionExtensionTestCase.java
@@ -110,9 +110,6 @@ public class LogFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase4() throws Exception {
         logger.info("LogFunctionExtension exceptionTestCase4");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (number double, base double);";
 
@@ -127,6 +124,9 @@ public class LogFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -134,16 +134,12 @@ public class LogFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 2f});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains(""));
         siddhiAppRuntime.shutdown();
     }
 
     @Test
     public void exceptionTestCase5() throws Exception {
         logger.info("LogFunctionExtension exceptionTestCase5");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (number double, base double);";
 
@@ -158,6 +154,9 @@ public class LogFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -165,7 +164,6 @@ public class LogFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{34, null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains(""));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/LogFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/LogFunctionExtensionTestCase.java
@@ -29,11 +29,18 @@ import io.siddhi.core.util.EventPrinter;
 import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class LogFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(LogFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -124,6 +131,7 @@ public class LogFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -134,6 +142,7 @@ public class LogFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 2f});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 
@@ -154,6 +163,7 @@ public class LogFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -164,6 +174,7 @@ public class LogFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{34, null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/MaxFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/MaxFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class MaxFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(MaxFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -122,6 +129,7 @@ public class MaxFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -132,6 +140,7 @@ public class MaxFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 91});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 
@@ -152,6 +161,7 @@ public class MaxFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -162,6 +172,7 @@ public class MaxFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{123.67d, null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/MaxFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/MaxFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -110,9 +108,6 @@ public class MaxFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase4() throws Exception {
         logger.info("MaxFunctionExtension exceptionTestCase4");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double,inValue2 int);";
 
@@ -127,6 +122,9 @@ public class MaxFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -134,16 +132,12 @@ public class MaxFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 91});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:max() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
     @Test
     public void exceptionTestCase5() throws Exception {
         logger.info("MaxFunctionExtension exceptionTestCase5");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double,inValue2 int);";
 
@@ -158,6 +152,9 @@ public class MaxFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -165,7 +162,6 @@ public class MaxFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{123.67d, null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:max() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/MinFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/MinFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class MinFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(MinFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -122,6 +129,7 @@ public class MinFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -132,6 +140,7 @@ public class MinFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 91});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 
@@ -152,6 +161,7 @@ public class MinFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -162,6 +172,7 @@ public class MinFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{123.67d, null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/MinFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/MinFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -110,9 +108,6 @@ public class MinFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase4() throws Exception {
         logger.info("MinFunctionExtension exceptionTestCase4");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double,inValue2 int);";
 
@@ -127,6 +122,9 @@ public class MinFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -134,16 +132,12 @@ public class MinFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null, 91});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:min() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
     @Test
     public void exceptionTestCase5() throws Exception {
         logger.info("MinFunctionExtension exceptionTestCase4");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double,inValue2 int);";
 
@@ -158,6 +152,9 @@ public class MinFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -165,7 +162,6 @@ public class MinFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{123.67d, null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:min() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/OctalFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/OctalFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class OctalFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(OctalFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class OctalFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class OctalFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/OctalFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/OctalFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class OctalFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("OctalFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue long);";
 
@@ -114,6 +109,9 @@ public class OctalFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class OctalFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:oct() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/ParseFloatFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ParseFloatFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class ParseFloatFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("ParseFloatFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue string);";
 
@@ -114,6 +109,9 @@ public class ParseFloatFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,8 +119,6 @@ public class ParseFloatFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:parseFloat() function cannot be "
-                                                                       + "null"));
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/ParseFloatFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ParseFloatFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ParseFloatFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(ParseFloatFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class ParseFloatFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class ParseFloatFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/ParseIntFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ParseIntFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ParseIntFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(ParseIntFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class ParseIntFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class ParseIntFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/ParseIntFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ParseIntFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class ParseIntFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("ParseIntFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue string);";
 
@@ -114,6 +109,9 @@ public class ParseIntFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class ParseIntFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:parseInt() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/ParseLongFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ParseLongFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ParseLongFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(ParseLongFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class ParseLongFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class ParseLongFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/ParseLongFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ParseLongFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class ParseLongFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("ParseLongFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue string);";
 
@@ -114,6 +109,9 @@ public class ParseLongFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,8 +119,6 @@ public class ParseLongFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:parseLong() function cannot be "
-                                                                       + "null"));
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/math/PowerFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/PowerFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class PowerFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(PowerFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -122,6 +129,7 @@ public class PowerFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -132,6 +140,7 @@ public class PowerFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null, 3.0d});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 
@@ -152,6 +161,7 @@ public class PowerFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -162,6 +172,7 @@ public class PowerFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{5.6d, null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/PowerFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/PowerFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -110,9 +108,6 @@ public class PowerFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase4() throws Exception {
         logger.info("PowerFunctionExtension exceptionTestCase4");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double, inValue2 double);";
 
@@ -127,6 +122,9 @@ public class PowerFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -134,16 +132,12 @@ public class PowerFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null, 3.0d});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains(""));
         siddhiAppRuntime.shutdown();
     }
 
     @Test
     public void exceptionTestCase5() throws Exception {
         logger.info("PowerFunctionExtension exceptionTestCase5");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue1 double, inValue2 double);";
 
@@ -158,6 +152,9 @@ public class PowerFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -165,7 +162,6 @@ public class PowerFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{5.6d, null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:power() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/RoundFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/RoundFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class RoundFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(RoundFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class RoundFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class RoundFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/RoundFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/RoundFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class RoundFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("RoundFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class RoundFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class RoundFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:round() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/SignFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/SignFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class SignFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(SignFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class SignFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class SignFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/SignFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/SignFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class SignFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("SignFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class SignFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class SignFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:signum() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/SinFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/SinFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class SinFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("SinFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class SinFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class SinFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:sin() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/SinFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/SinFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class SinFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(SinFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class SinFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class SinFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/SinhFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/SinhFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class SinhFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("SinhFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class SinhFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class SinhFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:sinh() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/SinhFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/SinhFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class SinhFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(SinhFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class SinhFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class SinhFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/TanFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/TanFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class TanFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("TanFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class TanFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class TanFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:tan() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/TanFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/TanFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TanFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(TanFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class TanFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class TanFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/TanhFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/TanhFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TanhFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(TanhFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class TanhFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class TanhFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/TanhFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/TanhFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class TanhFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("TanhFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class TanhFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,7 +119,6 @@ public class TanhFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:tanh() function cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/ToDegreesFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ToDegreesFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ToDegreesFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(ToDegreesFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class ToDegreesFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class ToDegreesFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/ToDegreesFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ToDegreesFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class ToDegreesFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("ToDegreesFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class ToDegreesFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,8 +119,6 @@ public class ToDegreesFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:toDegrees() function cannot be "
-                                                                       + "null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/ToRadiansFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ToRadiansFunctionExtensionTestCase.java
@@ -27,11 +27,18 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ToRadiansFunctionExtensionTestCase {
     protected static SiddhiManager siddhiManager;
     private static Logger logger = Logger.getLogger(ToRadiansFunctionExtensionTestCase.class);
+    private volatile boolean eventArrived;
+
+    @BeforeMethod
+    public void init() {
+        eventArrived = false;
+    }
 
     @Test
     public void testProcess() throws Exception {
@@ -109,6 +116,7 @@ public class ToRadiansFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                eventArrived = true;
                 for (Event event : inEvents) {
                     AssertJUnit.assertEquals(null, event.getData(0));
                 }
@@ -119,6 +127,7 @@ public class ToRadiansFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
+        AssertJUnit.assertTrue(eventArrived);
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/math/ToRadiansFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/math/ToRadiansFunctionExtensionTestCase.java
@@ -23,10 +23,8 @@ import io.siddhi.core.SiddhiManager;
 import io.siddhi.core.event.Event;
 import io.siddhi.core.exception.SiddhiAppCreationException;
 import io.siddhi.core.query.output.callback.QueryCallback;
-import io.siddhi.core.stream.StreamJunction;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.execution.math.util.UnitTestAppender;
 import org.apache.log4j.Logger;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -97,9 +95,6 @@ public class ToRadiansFunctionExtensionTestCase {
     @Test
     public void exceptionTestCase3() throws Exception {
         logger.info("ToRadiansFunctionExtension exceptionTestCase3");
-        UnitTestAppender appender = new UnitTestAppender();
-        logger = Logger.getLogger(StreamJunction.class);
-        logger.addAppender(appender);
         siddhiManager = new SiddhiManager();
         String inValueStream = "define stream InValueStream (inValue double);";
 
@@ -114,6 +109,9 @@ public class ToRadiansFunctionExtensionTestCase {
             public void receive(long timeStamp, Event[] inEvents,
                                 Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    AssertJUnit.assertEquals(null, event.getData(0));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime
@@ -121,8 +119,6 @@ public class ToRadiansFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Double[]{null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Input to the math:toRadians() function cannot be "
-                                                                       + "null"));
         siddhiAppRuntime.shutdown();
     }
 


### PR DESCRIPTION
## Purpose
> When a function is fronted by an outer join when the reset event comes into the function executor, we have to gracefully handle it since the event is null. Related to [siddhi-1320](https://github.com/siddhi-io/siddhi/issues/1320)